### PR TITLE
Fix/useoverlayposition flickr

### DIFF
--- a/packages/overlays/package.json
+++ b/packages/overlays/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-aria/overlays",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Overlay utilities. Part of react-native-aria",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/packages/overlays/src/useOverlayPosition.ts
+++ b/packages/overlays/src/useOverlayPosition.ts
@@ -53,6 +53,8 @@ interface AriaPositionProps extends PositionProps {
   shouldUpdatePosition?: boolean;
   /** Handler that is called when the overlay should close. */
   onClose?: () => void;
+  /** Determines whether the overlay should overlap with the trigger */
+  shouldOverlapWithTrigger?: boolean
 }
 
 type IMeasureResult = {
@@ -71,6 +73,7 @@ export function useOverlayPosition(props: AriaPositionProps) {
     crossOffset = 0,
     isOpen = true,
     shouldFlip = true,
+    shouldOverlapWithTrigger = false,
   } = props;
 
   let [position, setPosition] = React.useState<PositionResult>({
@@ -120,6 +123,7 @@ export function useOverlayPosition(props: AriaPositionProps) {
       },
       offset,
       crossOffset,
+      shouldOverlapWithTrigger,
     });
     setPosition(positions);
     setOpacity(1);
@@ -208,6 +212,7 @@ const calculatePosition = (opts: any): PositionResult => {
     boundaryElement,
     offset,
     crossOffset,
+    shouldOverlapWithTrigger
   } = opts;
 
   let childOffset: Offset = targetNode;
@@ -231,7 +236,8 @@ const calculatePosition = (opts: any): PositionResult => {
     containerOffsetWithBoundary,
     offset,
     crossOffset,
-    isContainerPositioned
+    isContainerPositioned,
+    shouldOverlapWithTrigger
   );
 };
 
@@ -247,7 +253,8 @@ function calculatePositionInternal(
   containerOffsetWithBoundary: Offset,
   offset: number,
   crossOffset: number,
-  isContainerPositioned: boolean
+  isContainerPositioned: boolean,
+  shouldOverlapWithTrigger: boolean
 ): PositionResult {
   let placementInfo = parsePlacement(placementInput);
   let { size, crossAxis, crossSize, placement, crossPlacement } = placementInfo;
@@ -346,6 +353,10 @@ function calculatePositionInternal(
   arrowPosition[crossAxis] =
     childOffset[crossAxis] - position[crossAxis] + childOffset[crossSize] / 2;
 
+  if (shouldOverlapWithTrigger) {
+    position[FLIPPED_DIRECTION[placementInfo.placement]] = position[FLIPPED_DIRECTION[placementInfo.placement]] - childOffset[size];
+  }
+  
   return {
     position,
     maxHeight,
@@ -382,10 +393,10 @@ function getDelta(
 function getMaxHeight(
   position: Position,
   boundaryDimensions: Dimensions,
-  containerOffsetWithBoundary: Offset,
+  _containerOffsetWithBoundary: Offset,
   childOffset: Offset,
-  margins: Position,
-  padding: number
+  _margins: Position,
+  _padding: number
 ) {
   return position.top != null
     ? // We want the distance between the top of the overlay to the bottom of the boundary
@@ -409,8 +420,8 @@ function computePosition(
   placementInfo: ParsedPlacement,
   offset: number,
   crossOffset: number,
-  containerOffsetWithBoundary: Offset,
-  isContainerPositioned: boolean
+  _containerOffsetWithBoundary: Offset,
+  _isContainerPositioned: boolean
 ) {
   let {
     placement,
@@ -466,9 +477,9 @@ function computePosition(
 
 function getAvailableSpace(
   boundaryDimensions: Dimensions,
-  containerOffsetWithBoundary: Offset,
+  _containerOffsetWithBoundary: Offset,
   childOffset: any,
-  margins: Position,
+  _margins: Position,
   padding: number,
   placementInfo: ParsedPlacement
 ) {

--- a/packages/overlays/src/useOverlayPosition.web.ts
+++ b/packages/overlays/src/useOverlayPosition.web.ts
@@ -1,1 +1,1 @@
-export { useOverlayPosition } from '@react-aria/overlays';
+export { useOverlayPosition } from '../src/web/overlays/src/useOverlayPosition';

--- a/packages/overlays/src/web/overlays/index.ts
+++ b/packages/overlays/src/web/overlays/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export * from './src';

--- a/packages/overlays/src/web/overlays/src/calculatePosition.ts
+++ b/packages/overlays/src/web/overlays/src/calculatePosition.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/overlays/src/web/overlays/src/calculatePosition.ts
+++ b/packages/overlays/src/web/overlays/src/calculatePosition.ts
@@ -1,0 +1,412 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {Axis, Placement, PlacementAxis, SizeAxis} from '@react-types/overlays';
+import getCss from 'dom-helpers/style';
+import getOffset from 'dom-helpers/query/offset';
+import getPosition from 'dom-helpers/query/position';
+import getScrollLeft from 'dom-helpers/query/scrollLeft';
+import getScrollTop from 'dom-helpers/query/scrollTop';
+import ownerDocument from 'dom-helpers/ownerDocument';
+
+interface Position {
+  top?: number,
+  left?: number,
+  bottom?: number,
+  right?: number
+}
+
+interface Dimensions {
+  width: number,
+  height: number,
+  top: number,
+  left: number,
+  scroll: Position
+}
+
+interface ParsedPlacement {
+  placement: PlacementAxis,
+  crossPlacement: PlacementAxis,
+  axis: Axis,
+  crossAxis: Axis,
+  size: SizeAxis,
+  crossSize: SizeAxis
+}
+
+interface Offset {
+  top: number,
+  left: number,
+  width: number,
+  height: number
+}
+
+interface PositionOpts {
+  placement: Placement,
+  targetNode: HTMLElement,
+  overlayNode: HTMLElement,
+  scrollNode: HTMLElement,
+  padding: number,
+  shouldFlip: boolean,
+  boundaryElement: HTMLElement,
+  offset: number,
+  crossOffset: number,
+  shouldOverlapWithTrigger: boolean
+}
+
+export interface PositionResult {
+  position?: Position,
+  arrowOffsetLeft?: number,
+  arrowOffsetTop?: number,
+  maxHeight?: number,
+  placement: PlacementAxis
+}
+
+const AXIS = {
+  top: 'top',
+  bottom: 'top',
+  left: 'left',
+  right: 'left'
+};
+
+const FLIPPED_DIRECTION = {
+  top: 'bottom',
+  bottom: 'top',
+  left: 'right',
+  right: 'left'
+};
+
+const CROSS_AXIS = {
+  top: 'left',
+  left: 'top'
+};
+
+const AXIS_SIZE = {
+  top: 'height',
+  left: 'width'
+};
+
+const PARSED_PLACEMENT_CACHE = {};
+
+// @ts-ignore
+let visualViewport = typeof window !== 'undefined' && window.visualViewport;
+
+function getContainerDimensions(containerNode: Element): Dimensions {
+  let width = 0, height = 0, top = 0, left = 0;
+  let scroll: Position = {};
+
+  if (containerNode.tagName === 'BODY') {
+    width = visualViewport?.width ?? document.documentElement.clientWidth;
+    height = visualViewport?.height ?? document.documentElement.clientHeight;
+
+    scroll.top =
+      getScrollTop(ownerDocument(containerNode).documentElement) ||
+      getScrollTop(containerNode);
+    scroll.left =
+      getScrollLeft(ownerDocument(containerNode).documentElement) ||
+      getScrollLeft(containerNode);
+  } else {
+    ({width, height, top, left} = getOffset(containerNode));
+    scroll.top = getScrollTop(containerNode);
+    scroll.left = getScrollLeft(containerNode);
+  }
+
+  return {width, height, scroll, top, left};
+}
+
+function getScroll(node: HTMLElement): Offset {
+  return {
+    top: node.scrollTop,
+    left: node.scrollLeft,
+    width: node.scrollWidth,
+    height: node.scrollHeight
+  };
+}
+
+function getDelta(
+  axis: Axis,
+  offset: number,
+  size: number,
+  containerDimensions: Dimensions,
+  padding: number
+) {
+  let containerScroll = containerDimensions.scroll[axis];
+  let containerHeight = containerDimensions[AXIS_SIZE[axis]];
+
+  let startEdgeOffset = offset - padding - containerScroll;
+  let endEdgeOffset = offset + padding - containerScroll + size;
+
+  if (startEdgeOffset < 0) {
+    return -startEdgeOffset;
+  } else if (endEdgeOffset > containerHeight) {
+    return Math.max(containerHeight - endEdgeOffset, -startEdgeOffset);
+  } else {
+    return 0;
+  }
+}
+
+function getMargins(node: HTMLElement): Position {
+  let style = window.getComputedStyle(node);
+  return {
+    top: parseInt(style.marginTop, 10) || 0,
+    bottom: parseInt(style.marginBottom, 10) || 0,
+    left: parseInt(style.marginLeft, 10) || 0,
+    right: parseInt(style.marginRight, 10) || 0
+  };
+}
+
+function parsePlacement(input: Placement): ParsedPlacement {
+  if (PARSED_PLACEMENT_CACHE[input]) {
+    return PARSED_PLACEMENT_CACHE[input];
+  }
+
+  let [placement, crossPlacement] = input.split(' ');
+  let axis: Axis = AXIS[placement] || 'right';
+  let crossAxis: Axis = CROSS_AXIS[axis];
+
+  if (!AXIS[crossPlacement]) {
+    crossPlacement = 'center';
+  }
+
+  let size = AXIS_SIZE[axis];
+  let crossSize = AXIS_SIZE[crossAxis];
+  PARSED_PLACEMENT_CACHE[input] = {placement, crossPlacement, axis, crossAxis, size, crossSize};
+  return PARSED_PLACEMENT_CACHE[input];
+}
+
+function computePosition(
+  childOffset: Offset,
+  boundaryDimensions: Dimensions,
+  overlaySize: Offset,
+  placementInfo: ParsedPlacement,
+  offset: number,
+  crossOffset: number,
+  containerOffsetWithBoundary: Offset,
+  isContainerPositioned: boolean
+) {
+  let {placement, crossPlacement, axis, crossAxis, size, crossSize} = placementInfo;
+  let position: Position = {};
+
+  // button position
+  position[crossAxis] = childOffset[crossAxis];
+  if (crossPlacement === 'center') {
+    //  + (button size / 2) - (overlay size / 2)
+    // at this point the overlay center should match the button center
+    position[crossAxis] += (childOffset[crossSize] - overlaySize[crossSize]) / 2;
+  } else if (crossPlacement !== crossAxis) {
+    //  + (button size) - (overlay size)
+    // at this point the overlay bottom should match the button bottom
+    position[crossAxis] += (childOffset[crossSize] - overlaySize[crossSize]);
+  }/* else {
+    the overlay top should match the button top
+  } */
+  // add the crossOffset from props
+  position[crossAxis] += crossOffset;
+
+  // this is button center position - the overlay size + half of the button to align bottom of overlay with button center
+  let minViablePosition = childOffset[crossAxis] + (childOffset[crossSize] / 2) - overlaySize[crossSize];
+  // this is button position of center, aligns top of overlay with button center
+  let maxViablePosition = childOffset[crossAxis] + (childOffset[crossSize] / 2);
+
+  // clamp it into the range of the min/max positions
+  position[crossAxis] = Math.min(Math.max(minViablePosition, position[crossAxis]), maxViablePosition);
+
+  // Floor these so the position isn't placed on a partial pixel, only whole pixels. Shouldn't matter if it was floored or ceiled, so chose one.
+  if (placement === axis) {
+    // If the container is positioned (non-static), then we use the container's actual
+    // height, as `bottom` will be relative to this height.  But if the container is static,
+    // then it can only be the `document.body`, and `bottom` will be relative to _its_
+    // container, which should be as large as boundaryDimensions.
+    const containerHeight = (isContainerPositioned ? containerOffsetWithBoundary[size] : boundaryDimensions[size]);
+    position[FLIPPED_DIRECTION[axis]] = Math.floor(containerHeight - childOffset[axis] + offset);
+  } else {
+    position[axis] = Math.floor(childOffset[axis] + childOffset[size] + offset);
+  }
+
+  return position;
+}
+
+function getMaxHeight(
+  position: Position,
+  boundaryDimensions: Dimensions,
+  containerOffsetWithBoundary: Offset,
+  childOffset: Offset,
+  margins: Position,
+  padding: number
+) {
+  return position.top != null
+    // We want the distance between the top of the overlay to the bottom of the boundary
+    ? Math.max(0,
+      (boundaryDimensions.height + boundaryDimensions.top + boundaryDimensions.scroll.top) // this is the bottom of the boundary
+      - (containerOffsetWithBoundary.top + position.top) // this is the top of the overlay
+      - (margins.top + margins.bottom + padding) // save additional space for margin and padding
+    )
+    // We want the distance between the top of the trigger to the top of the boundary
+    : Math.max(0,
+      (childOffset.top + containerOffsetWithBoundary.top) // this is the top of the trigger
+      - (boundaryDimensions.top + boundaryDimensions.scroll.top) // this is the top of the boundary
+      - (margins.top + margins.bottom + padding) // save additional space for margin and padding
+    );
+}
+
+function getAvailableSpace(
+  boundaryDimensions: Dimensions,
+  containerOffsetWithBoundary: Offset,
+  childOffset: Offset,
+  margins: Position,
+  padding: number,
+  placementInfo: ParsedPlacement
+) {
+  let {placement, axis, size} = placementInfo;
+  if (placement === axis) {
+    return Math.max(0, childOffset[axis] - boundaryDimensions[axis] - boundaryDimensions.scroll[axis] + containerOffsetWithBoundary[axis] - margins[axis] - margins[FLIPPED_DIRECTION[axis]] - padding);
+  }
+
+  return Math.max(0, boundaryDimensions[size] + boundaryDimensions[axis] + boundaryDimensions.scroll[axis] - containerOffsetWithBoundary[axis] - childOffset[axis] - childOffset[size] - margins[axis] - margins[FLIPPED_DIRECTION[axis]] - padding);
+}
+
+export function calculatePositionInternal(
+  placementInput: Placement,
+  childOffset: Offset,
+  overlaySize: Offset,
+  scrollSize: Offset,
+  margins: Position,
+  padding: number,
+  flip: boolean,
+  boundaryDimensions: Dimensions,
+  containerOffsetWithBoundary: Offset,
+  offset: number,
+  crossOffset: number,
+  isContainerPositioned: boolean,
+  shouldOverlapWithTrigger: boolean
+): PositionResult {
+  let placementInfo = parsePlacement(placementInput);
+  let {size, crossAxis, crossSize, placement, crossPlacement, axis} = placementInfo;
+  let position = computePosition(childOffset, boundaryDimensions, overlaySize, placementInfo, offset, crossOffset, containerOffsetWithBoundary, isContainerPositioned);
+  let normalizedOffset = offset;
+  let space = getAvailableSpace(
+    boundaryDimensions,
+    containerOffsetWithBoundary,
+    childOffset,
+    margins,
+    padding + offset,
+    placementInfo
+  );
+
+  // Check if the scroll size of the overlay is greater than the available space to determine if we need to flip
+  if (flip && scrollSize[size] > space) {
+    let flippedPlacementInfo = parsePlacement(`${FLIPPED_DIRECTION[placement]} ${crossPlacement}` as Placement);
+    let flippedPosition = computePosition(childOffset, boundaryDimensions, overlaySize, flippedPlacementInfo, offset, crossOffset, containerOffsetWithBoundary, isContainerPositioned);
+    let flippedSpace = getAvailableSpace(
+      boundaryDimensions,
+      containerOffsetWithBoundary,
+      childOffset,
+      margins,
+      padding + offset,
+      flippedPlacementInfo
+    );
+
+    // If the available space for the flipped position is greater than the original available space, flip.
+    if (flippedSpace > space) {
+      placementInfo = flippedPlacementInfo;
+      position = flippedPosition;
+      normalizedOffset = offset;
+    }
+  }
+
+  let delta = getDelta(crossAxis, position[crossAxis], overlaySize[crossSize], boundaryDimensions, padding);
+  position[crossAxis] += delta;
+
+  let maxHeight = getMaxHeight(
+    position,
+    boundaryDimensions,
+    containerOffsetWithBoundary,
+    childOffset,
+    margins,
+    padding
+  );
+
+  overlaySize.height = Math.min(overlaySize.height, maxHeight);
+
+  position = computePosition(childOffset, boundaryDimensions, overlaySize, placementInfo, normalizedOffset, crossOffset, containerOffsetWithBoundary, isContainerPositioned);
+  delta = getDelta(crossAxis, position[crossAxis], overlaySize[crossSize], boundaryDimensions, padding);
+  position[crossAxis] += delta;
+
+  let arrowPosition: Position = {};
+  arrowPosition[crossAxis] = (childOffset[crossAxis] - position[crossAxis] + childOffset[crossSize] / 2);
+
+  if (shouldOverlapWithTrigger) {
+    position[FLIPPED_DIRECTION[placementInfo.placement]] = position[FLIPPED_DIRECTION[placementInfo.placement]] - childOffset[size];
+  }
+
+  return {
+    position,
+    maxHeight: maxHeight,
+    arrowOffsetLeft: arrowPosition.left,
+    arrowOffsetTop: arrowPosition.top,
+    placement: placementInfo.placement
+  };
+}
+
+/**
+ * Determines where to place the overlay with regards to the target and the position of an optional indicator.
+ */
+export function calculatePosition(opts: PositionOpts): PositionResult {
+  let {
+    placement,
+    targetNode,
+    overlayNode,
+    scrollNode,
+    padding,
+    shouldFlip,
+    boundaryElement,
+    offset,
+    crossOffset,
+    shouldOverlapWithTrigger
+  } = opts;
+
+  let container = overlayNode.offsetParent || document.body;
+  let isBodyContainer = container.tagName === 'BODY';
+  const containerPositionStyle = window.getComputedStyle(container).position;
+  let isContainerPositioned = !!containerPositionStyle && containerPositionStyle !== 'static';
+  let childOffset: Offset = isBodyContainer ? getOffset(targetNode) : getPosition(targetNode, container);
+
+  if (!isBodyContainer) {
+    childOffset.top += parseInt(getCss(targetNode, 'marginTop'), 10) || 0;
+    childOffset.left += parseInt(getCss(targetNode, 'marginLeft'), 10) || 0;
+  }
+
+  let overlaySize: Offset = getOffset(overlayNode);
+  let margins = getMargins(overlayNode);
+  overlaySize.width += margins.left + margins.right;
+  overlaySize.height += margins.top + margins.bottom;
+
+  let scrollSize = getScroll(scrollNode);
+  let boundaryDimensions = getContainerDimensions(boundaryElement);
+  let containerOffsetWithBoundary: Offset = boundaryElement.tagName === 'BODY' ? getOffset(container) : getPosition(container, boundaryElement);
+
+
+  return calculatePositionInternal(
+    placement,
+    childOffset,
+    overlaySize,
+    scrollSize,
+    margins,
+    padding,
+    shouldFlip,
+    boundaryDimensions,
+    containerOffsetWithBoundary,
+    offset,
+    crossOffset,
+    isContainerPositioned,
+    shouldOverlapWithTrigger
+  );
+}

--- a/packages/overlays/src/web/overlays/src/index.ts
+++ b/packages/overlays/src/web/overlays/src/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export * from './useOverlayPosition';

--- a/packages/overlays/src/web/overlays/src/useCloseOnScroll.ts
+++ b/packages/overlays/src/web/overlays/src/useCloseOnScroll.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {RefObject, useEffect} from 'react';
+
+// This behavior moved from useOverlayTrigger to useOverlayPosition.
+// For backward compatibility, where useOverlayTrigger handled hiding the popover on close,
+// it sets a close function here mapped from the trigger element. This way we can avoid
+// forcing users to pass an onClose function to useOverlayPosition which could be considered
+// a breaking change.
+export const onCloseMap: WeakMap<HTMLElement, () => void> = new WeakMap();
+
+interface CloseOnScrollOptions {
+  triggerRef: RefObject<HTMLElement>,
+  isOpen?: boolean,
+  onClose?: () => void
+}
+
+/** @private */
+export function useCloseOnScroll(opts: CloseOnScrollOptions) {
+  let {triggerRef, isOpen, onClose} = opts;
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    let onScroll = (e: MouseEvent) => {
+      // Ignore if scrolling an scrollable region outside the trigger's tree.
+      let target = e.target as HTMLElement;
+      if (!triggerRef.current || !target.contains(triggerRef.current)) {
+        return;
+      }
+
+      let onCloseHandler = onClose || onCloseMap.get(triggerRef.current);
+      if (onCloseHandler) {
+        onCloseHandler();
+      }
+    };
+
+    window.addEventListener('scroll', onScroll, true);
+    return () => {
+      window.removeEventListener('scroll', onScroll, true);
+    };
+  }, [isOpen, onClose, triggerRef]);
+}

--- a/packages/overlays/src/web/overlays/src/useCloseOnScroll.ts
+++ b/packages/overlays/src/web/overlays/src/useCloseOnScroll.ts
@@ -1,3 +1,4 @@
+//@ts-nocheck
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/overlays/src/web/overlays/src/useOverlayPosition.ts
+++ b/packages/overlays/src/web/overlays/src/useOverlayPosition.ts
@@ -1,3 +1,4 @@
+//@ts-nocheck
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/overlays/src/web/overlays/src/useOverlayPosition.ts
+++ b/packages/overlays/src/web/overlays/src/useOverlayPosition.ts
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {calculatePosition, PositionResult} from './calculatePosition';
+import {HTMLAttributes, RefObject, useCallback, useLayoutEffect, useRef, useState} from 'react';
+import {Placement, PlacementAxis, PositionProps} from '@react-types/overlays';
+import {useCloseOnScroll} from './useCloseOnScroll';
+import {useLocale} from '@react-aria/i18n';
+
+interface AriaPositionProps extends PositionProps {
+  /**
+   * Element that that serves as the positioning boundary.
+   * @default document.body
+   */
+  boundaryElement?: HTMLElement,
+  /**
+   * The ref for the element which the overlay positions itself with respect to.
+   */
+  targetRef: RefObject<HTMLElement>,
+  /**
+   * The ref for the overlay element.
+   */
+  overlayRef: RefObject<HTMLElement>,
+  /**
+   * A ref for the scrollable region within the overlay.
+   * @default overlayRef
+   */
+  scrollRef?: RefObject<HTMLElement>,
+  /**
+   * Whether the overlay should update its position automatically.
+   * @default true
+   */
+  shouldUpdatePosition?: boolean,
+  /** Handler that is called when the overlay should close. */
+  onClose?: () => void
+  /** Determines whether the overlay should overlap with the trigger */
+  shouldOverlapWithTrigger?: boolean
+}
+
+interface PositionAria {
+  /** Props for the overlay container element. */
+  overlayProps: HTMLAttributes<Element>,
+  /** Props for the overlay tip arrow if any. */
+  arrowProps: HTMLAttributes<Element>,
+  /** Placement of the overlay with respect to the overlay trigger. */
+  placement: PlacementAxis,
+  /** Updates the position of the overlay. */
+  updatePosition(): void
+}
+
+// @ts-ignore
+let visualViewport = typeof window !== 'undefined' && window.visualViewport;
+
+/**
+ * Handles positioning overlays like popovers and menus relative to a trigger
+ * element, and updating the position when the window resizes.
+ */
+export function useOverlayPosition(props: AriaPositionProps): PositionAria {
+  let {direction} = useLocale();
+  let {
+    targetRef,
+    overlayRef,
+    scrollRef = overlayRef,
+    placement = 'bottom' as Placement,
+    containerPadding = 12,
+    shouldFlip = true,
+    boundaryElement = typeof document !== 'undefined' ? document.body : null,
+    offset = 0,
+    crossOffset = 0,
+    shouldUpdatePosition = true,
+    isOpen = true,
+    shouldOverlapWithTrigger = false,
+    onClose
+  } = props;
+  let [position, setPosition] = useState<PositionResult>({
+    position: {},
+    arrowOffsetLeft: undefined,
+    arrowOffsetTop: undefined,
+    maxHeight: undefined,
+    placement: undefined
+  });
+
+  let deps = [
+    shouldUpdatePosition,
+    placement,
+    overlayRef.current,
+    targetRef.current,
+    scrollRef.current,
+    containerPadding,
+    shouldFlip,
+    boundaryElement,
+    offset,
+    crossOffset,
+    isOpen,
+    direction
+  ];
+
+  let updatePosition = useCallback(() => {
+    if (shouldUpdatePosition === false || !isOpen || !overlayRef.current || !targetRef.current || !scrollRef.current || !boundaryElement) {
+      return;
+    }
+
+    setPosition(
+      calculatePosition({
+        placement: translateRTL(placement, direction),
+        overlayNode: overlayRef.current,
+        targetNode: targetRef.current,
+        scrollNode: scrollRef.current,
+        padding: containerPadding,
+        shouldFlip,
+        boundaryElement,
+        offset,
+        crossOffset,
+        shouldOverlapWithTrigger
+      })
+    );
+  }, deps);
+
+  // Update position when anything changes
+  useLayoutEffect(updatePosition, deps);
+
+  // Update position on window resize
+  useResize(updatePosition);
+
+  // Reposition the overlay and do not close on scroll while the visual viewport is resizing.
+  // This will ensure that overlays adjust their positioning when the iOS virtual keyboard appears.
+  let isResizing = useRef(false);
+  useLayoutEffect(() => {
+    let timeout: NodeJS.Timeout;
+    let onResize = () => {
+      isResizing.current = true;
+      clearTimeout(timeout);
+
+      timeout = setTimeout(() => {
+        isResizing.current = false;
+      }, 500);
+
+      updatePosition();
+    };
+
+    visualViewport?.addEventListener('resize', onResize);
+
+    return () => {
+      visualViewport?.removeEventListener('resize', onResize);
+    };
+  }, [updatePosition]);
+
+  let close = useCallback(() => {
+    if (!isResizing.current) {
+      onClose();
+    }
+  }, [onClose, isResizing]);
+
+  // When scrolling a parent scrollable region of the trigger (other than the body),
+  // we hide the popover. Otherwise, its position would be incorrect.
+  useCloseOnScroll({
+    triggerRef: targetRef,
+    isOpen,
+    onClose: onClose ? close : undefined
+  });
+
+  return {
+    overlayProps: {
+      style: {
+        position: 'absolute',
+        zIndex: 100000, // should match the z-index in ModalTrigger
+        ...position.position,
+        maxHeight: position.maxHeight
+      }
+    },
+    placement: position.placement,
+    arrowProps: {
+      style: {
+        left: position.arrowOffsetLeft,
+        top: position.arrowOffsetTop
+      }
+    },
+    updatePosition
+  };
+}
+
+function useResize(onResize) {
+  useLayoutEffect(() => {
+    window.addEventListener('resize', onResize, false);
+    return () => {
+      window.removeEventListener('resize', onResize, false);
+    };
+  }, [onResize]);
+}
+
+function translateRTL(position, direction) {
+  if (direction === 'rtl') {
+    return position.replace('start', 'right').replace('end', 'left');
+  }
+  return position.replace('start', 'left').replace('end', 'right');
+}

--- a/packages/overlays/src/web/overlays/src/usePreventScroll.ts
+++ b/packages/overlays/src/web/overlays/src/usePreventScroll.ts
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {chain, getScrollParent, isIOS, useLayoutEffect} from '@react-aria/utils';
+
+interface PreventScrollOptions {
+  /** Whether the scroll lock is disabled. */
+  isDisabled?: boolean
+}
+
+// @ts-ignore
+const visualViewport = typeof window !== 'undefined' && window.visualViewport;
+
+// HTML input types that do not cause the software keyboard to appear.
+const nonTextInputTypes = new Set([
+  'checkbox',
+  'radio',
+  'range',
+  'color',
+  'file',
+  'image',
+  'button',
+  'submit',
+  'reset'
+]);
+
+/**
+ * Prevents scrolling on the document body on mount, and
+ * restores it on unmount. Also ensures that content does not
+ * shift due to the scrollbars disappearing.
+ */
+export function usePreventScroll(options: PreventScrollOptions = {}) {
+  let {isDisabled} = options;
+
+  useLayoutEffect(() => {
+    if (isDisabled) {
+      return;
+    }
+
+    if (isIOS()) {
+      return preventScrollMobileSafari();
+    } else {
+      return preventScrollStandard();
+    }
+  }, [isDisabled]);
+}
+
+// For most browsers, all we need to do is set `overflow: hidden` on the root element, and
+// add some padding to prevent the page from shifting when the scrollbar is hidden.
+function preventScrollStandard() {
+  return chain(
+    setStyle(document.documentElement, 'paddingRight', `${window.innerWidth - document.documentElement.clientWidth}px`),
+    setStyle(document.documentElement, 'overflow', 'hidden')
+  );
+}
+
+// Mobile Safari is a whole different beast. Even with overflow: hidden,
+// it still scrolls the page in many situations:
+//
+// 1. When the bottom toolbar and address bar are collapsed, page scrolling is always allowed.
+// 2. When the keyboard is visible, the viewport does not resize. Instead, the keyboard covers part of
+//    it, so it becomes scrollable.
+// 3. When tapping on an input, the page always scrolls so that the input is centered in the visual viewport.
+//    This may cause even fixed position elements to scroll off the screen.
+// 4. When using the next/previous buttons in the keyboard to navigate between inputs, the whole page always
+//    scrolls, even if the input is inside a nested scrollable element that could be scrolled instead.
+//
+// In order to work around these cases, and prevent scrolling without jankiness, we do a few things:
+//
+// 1. Prevent default on `touchmove` events that are not in a scrollable element. This prevents touch scrolling
+//    on the window.
+// 2. Prevent default on `touchmove` events inside a scrollable element when the scroll position is at the
+//    top or bottom. This avoids the whole page scrolling instead, but does prevent overscrolling.
+// 3. Prevent default on `touchend` events on input elements and handle focusing the element ourselves.
+// 4. When focusing an input, apply a transform to trick Safari into thinking the input is at the top
+//    of the page, which prevents it from scrolling the page. After the input is focused, scroll the element
+//    into view ourselves, without scrolling the whole page.
+// 5. Offset the body by the scroll position using a negative margin and scroll to the top. This should appear the
+//    same visually, but makes the actual scroll position always zero. This is required to make all of the
+//    above work or Safari will still try to scroll the page when focusing an input.
+// 6. As a last resort, handle window scroll events, and scroll back to the top. This can happen when attempting
+//    to navigate to an input with the next/previous buttons that's outside a modal.
+function preventScrollMobileSafari() {
+  let scrollable: Element;
+  let lastY = 0;
+  let onTouchStart = (e: TouchEvent) => {
+    // Store the nearest scrollable parent element from the element that the user touched.
+    scrollable = getScrollParent(e.target as Element);
+    if (scrollable === document.documentElement && scrollable === document.body) {
+      return;
+    }
+
+    lastY = e.changedTouches[0].pageY;
+  };
+
+  let onTouchMove = (e: TouchEvent) => {
+    // Prevent scrolling the window.
+    if (scrollable === document.documentElement || scrollable === document.body) {
+      e.preventDefault();
+      return;
+    }
+
+    // Prevent scrolling up when at the top and scrolling down when at the bottom
+    // of a nested scrollable area, otherwise mobile Safari will start scrolling
+    // the window instead. Unfortunately, this disables bounce scrolling when at
+    // the top but it's the best we can do.
+    let y = e.changedTouches[0].pageY;
+    let scrollTop = scrollable.scrollTop;
+    let bottom = scrollable.scrollHeight - scrollable.clientHeight;
+
+    if ((scrollTop <= 0 && y > lastY) || (scrollTop >= bottom && y < lastY)) {
+      e.preventDefault();
+    }
+
+    lastY = y;
+  };
+
+  let onTouchEnd = (e: TouchEvent) => {
+    let target = e.target as HTMLElement;
+    if (target instanceof HTMLInputElement && !nonTextInputTypes.has(target.type)) {
+      e.preventDefault();
+
+      // Apply a transform to trick Safari into thinking the input is at the top of the page
+      // so it doesn't try to scroll it into view. When tapping on an input, this needs to
+      // be done before the "focus" event, so we have to focus the element ourselves.
+      target.style.transform = 'translateY(-2000px)';
+      target.focus();
+      requestAnimationFrame(() => {
+        target.style.transform = '';
+      });
+    }
+  };
+
+  let onFocus = (e: FocusEvent) => {
+    let target = e.target as HTMLElement;
+    if (target instanceof HTMLInputElement && !nonTextInputTypes.has(target.type)) {
+      // Transform also needs to be applied in the focus event in cases where focus moves
+      // other than tapping on an input directly, e.g. the next/previous buttons in the
+      // software keyboard. In these cases, it seems applying the transform in the focus event
+      // is good enough, whereas when tapping an input, it must be done before the focus event. 🤷‍♂️
+      target.style.transform = 'translateY(-2000px)';
+      requestAnimationFrame(() => {
+        target.style.transform = '';
+
+        // This will have prevented the browser from scrolling the focused element into view,
+        // so we need to do this ourselves in a way that doesn't cause the whole page to scroll.
+        if (visualViewport) {
+          if (visualViewport.height < window.innerHeight) {
+            // If the keyboard is already visible, do this after one additional frame
+            // to wait for the transform to be removed.
+            requestAnimationFrame(() => {
+              scrollIntoView(target);
+            });
+          } else {
+            // Otherwise, wait for the visual viewport to resize before scrolling so we can
+            // measure the correct position to scroll to.
+            visualViewport.addEventListener('resize', () => scrollIntoView(target), {once: true});
+          }
+        }
+      });
+    }
+  };
+
+  let onWindowScroll = () => {
+    // Last resort. If the window scrolled, scroll it back to the top.
+    // It should always be at the top because the body will have a negative margin (see below).
+    window.scrollTo(0, 0);
+  };
+
+  // Record the original scroll position so we can restore it.
+  // Then apply a negative margin to the body to offset it by the scroll position. This will
+  // enable us to scroll the window to the top, which is required for the rest of this to work.
+  let scrollX = window.pageXOffset;
+  let scrollY = window.pageYOffset;
+  let restoreStyles = chain(
+    setStyle(document.documentElement, 'paddingRight', `${window.innerWidth - document.documentElement.clientWidth}px`),
+    setStyle(document.documentElement, 'overflow', 'hidden'),
+    setStyle(document.body, 'marginTop', `-${scrollY}px`)
+  );
+
+  // Scroll to the top. The negative margin on the body will make this appear the same.
+  window.scrollTo(0, 0);
+
+  let removeEvents = chain(
+    addEvent(document, 'touchstart', onTouchStart, {passive: false, capture: true}),
+    addEvent(document, 'touchmove', onTouchMove, {passive: false, capture: true}),
+    addEvent(document, 'touchend', onTouchEnd, {passive: false, capture: true}),
+    addEvent(document, 'focus', onFocus, true),
+    addEvent(window, 'scroll', onWindowScroll)
+  );
+
+  return () => {
+    // Restore styles and scroll the page back to where it was.
+    restoreStyles();
+    removeEvents();
+    window.scrollTo(scrollX, scrollY);
+  };
+}
+
+// Sets a CSS property on an element, and returns a function to revert it to the previous value.
+function setStyle(element: HTMLElement, style: string, value: string) {
+  let cur = element.style[style];
+  element.style[style] = value;
+  return () => {
+    element.style[style] = cur;
+  };
+}
+
+// Adds an event listener to an element, and returns a function to remove it.
+function addEvent<K extends keyof GlobalEventHandlersEventMap>(
+  target: EventTarget,
+  event: K,
+  handler: (this: Document, ev: GlobalEventHandlersEventMap[K]) => any,
+  options?: boolean | AddEventListenerOptions
+) {
+  target.addEventListener(event, handler, options);
+  return () => {
+    target.removeEventListener(event, handler, options);
+  };
+}
+
+function scrollIntoView(target: Element) {
+  // Find the parent scrollable element and adjust the scroll position if the target is not already in view.
+  let scrollable = getScrollParent(target);
+  if (scrollable !== document.documentElement && scrollable !== document.body) {
+    let scrollableTop = scrollable.getBoundingClientRect().top;
+    let targetTop = target.getBoundingClientRect().top;
+    if (targetTop > scrollableTop + target.clientHeight) {
+      scrollable.scrollTop += targetTop - scrollableTop;
+    }
+  }
+}

--- a/packages/overlays/src/web/overlays/src/usePreventScroll.ts
+++ b/packages/overlays/src/web/overlays/src/usePreventScroll.ts
@@ -1,3 +1,4 @@
+//@ts-nocheck
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
1. Fixes useOverlayPosition flicker on web
Reproducible demo - https://codesandbox.io/s/wonderful-christian-sd7mb?file=/src/PopoverExample.js
Cause - useOverlayPosition sets position after first render (in useEffect).
Solution - Using useLayoutEffect instead of useEffect solves the issue.

2. Adds a new `shouldOverlapWithTrigger` prop which can be position overlay and overlap it with the trigger.

