### PR TITLE
fix(Slider): Set min and max of `onAccessibilityAction` to the correct values

### DIFF
--- a/packages/slider/src/useSliderThumb.ts
+++ b/packages/slider/src/useSliderThumb.ts
@@ -82,8 +82,8 @@ export function useSliderThumb(
   state.setThumbEditable(index, !isDisabled);
 
   const onAccessibilityAction = (event: any) => {
-    const max = state.getThumbMinValue(index);
-    const min = state.getThumbMaxValue(index);
+    const max = state.getThumbMaxValue(index);
+    const min = state.getThumbMinValue(index);
     const value = state.getThumbValue(index);
 
     const incrementValue = Math.min(value + state.step ?? 1, max);


### PR DESCRIPTION
The useSlider Hooks `onAccessibilityAction` does not take the correct action because the min and max values are reversed.
This PR will fix that.